### PR TITLE
win10ではWin+Ctrlの上下が動かないので、Win+Altにする

### DIFF
--- a/VdLabel/DesktopCatalogViewModel.cs
+++ b/VdLabel/DesktopCatalogViewModel.cs
@@ -77,11 +77,11 @@ internal sealed partial class DesktopCatalogViewModel : ObservableObject, IDispo
     partial void OnHeightChanged(double value)
     {
         var rows = (this.Desktops.Count / this.Columns) + (this.Desktops.Count % this.Columns == 0 ? 0 : 1);
-        this.Height = Math.Min(SystemParameters.PrimaryScreenHeight * 0.8, 280 * rows);
+        this.Height = Math.Min(SystemParameters.PrimaryScreenHeight * 0.8, 280 * rows) + 2;
     }
 
     partial void OnWidthChanged(double value)
-        => this.Width = this.Columns * 280;
+        => this.Width = this.Columns * 280 + 2;
     partial void OnTopChanged(double value)
         => this.Top = (SystemParameters.PrimaryScreenHeight - this.Height) / 2;
     partial void OnLeftChanged(double value)

--- a/VdLabel/MainWindow.xaml.cs
+++ b/VdLabel/MainWindow.xaml.cs
@@ -56,8 +56,17 @@ public partial class MainWindow : FluentWindow
             var key = (i < 10 ? i : i - 10) + Key.NumPad0;
             RegisterHotKey(new(window.Handle), i, mod, (uint)KeyInterop.VirtualKeyFromKey(key));
         }
-        RegisterHotKey(new(window.Handle), 20, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_CONTROL, (uint)KeyInterop.VirtualKeyFromKey(Key.Up));
-        RegisterHotKey(new(window.Handle), 21, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_CONTROL, (uint)KeyInterop.VirtualKeyFromKey(Key.Down));
+        // Win10とWin11で使えるのショートカットが異なるので、バージョンで判定して登録するショートカットを切り替える
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000, 0))
+        {
+            RegisterHotKey(new(window.Handle), 20, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_CONTROL, (uint)KeyInterop.VirtualKeyFromKey(Key.Up));
+            RegisterHotKey(new(window.Handle), 21, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_CONTROL, (uint)KeyInterop.VirtualKeyFromKey(Key.Down));
+        }
+        else
+        {
+            RegisterHotKey(new(window.Handle), 20, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_ALT, (uint)KeyInterop.VirtualKeyFromKey(Key.Up));
+            RegisterHotKey(new(window.Handle), 21, HOT_KEY_MODIFIERS.MOD_WIN | HOT_KEY_MODIFIERS.MOD_ALT, (uint)KeyInterop.VirtualKeyFromKey(Key.Down));
+        }
         var source = HwndSource.FromHwnd(window.Handle);
         source.AddHook(WndProc);
 
@@ -74,7 +83,7 @@ public partial class MainWindow : FluentWindow
         {
             this.virualDesktopService.Swtich(i);
         }
-        else if(i == 20)
+        else if (i == 20)
         {
             this.virualDesktopService.PopupOverlay();
         }


### PR DESCRIPTION
win10ではWin+Ctrlの上下が動かないので、Win+Altにする